### PR TITLE
Add pen colours

### DIFF
--- a/rmpdf/pdf.go
+++ b/rmpdf/pdf.go
@@ -148,7 +148,7 @@ func constructPageWithLayers(rmf files.RMFileInfo, pageno int, pdf *gofpdf.Fpdf)
 			UnknownPens[int(path.Pen)]++
 			ss = StrokeSettings["fineliner"]
 		}
-		pdf.SetDrawColor(ss.selectColour(&layerCustomColour))
+		pdf.SetDrawColor(ss.selectColour(&layerCustomColour, path.Colour))
 		// pdf.SetFillSpotColor("White", 100) // 0% tint
 		pdf.SetLineWidth(ss.Width(path.Width))
 		if ss.Opacity != 1.0 {

--- a/rmpdf/stroke.go
+++ b/rmpdf/stroke.go
@@ -26,7 +26,7 @@ import (
 // ColourOverride property determines if the colour of the stroke may be
 // manually overridden by command-line options.
 type StrokeSetting struct {
-	Colour         color.RGBA
+	Colour         map[int]color.RGBA
 	StdWidth       float32
 	Opacity        float64
 	ColourOverride bool
@@ -54,57 +54,57 @@ var StrokeMap = map[int]string{
 // Set of pen default settings
 var StrokeSettings = map[string]StrokeSetting{
 	"pen": {
-		Colour:         colornames.Black,
+		Colour:         map[int]color.RGBA{ 0:colornames.Black, 1:colornames.Gray, 2:colornames.White },
 		StdWidth:       2.0,
 		Opacity:        1,
 		ColourOverride: true,
 	},
 	"highlighter": {
-		Colour:         colornames.Blue,
+		Colour:         map[int]color.RGBA{0:colornames.Yellow},
 		StdWidth:       15.0,
 		Opacity:        0.4,
 		ColourOverride: true,
 	},
 	"fineliner": {
-		Colour:         colornames.Blue,
+		Colour:         map[int]color.RGBA{ 0:colornames.Black, 1:colornames.Darkgray, 2:colornames.White },
 		StdWidth:       1.0,
 		Opacity:        1,
 		ColourOverride: true,
 	},
 	"marker": {
-		Colour:         colornames.Black,
+		Colour:         map[int]color.RGBA{ 0:colornames.Red, 1:colornames.Green, 2:colornames.White },
 		StdWidth:       3.8,
 		Opacity:        1,
 		ColourOverride: true,
 	},
 	"ballpoint": {
 		// Colour  : color.RGBA{68, 68, 68, 225}, // greyish
-		Colour:   colornames.Slategray,
+		Colour:   map[int]color.RGBA{ 0:colornames.Darkslateblue, 1:colornames.Green, 2:color.RGBA{220, 220, 220, 220} },
 		StdWidth: 1.75,
 		Opacity:  0.8,
 	},
 	"pencil": {
-		Colour:   colornames.Black,
+		Colour:   map[int]color.RGBA{0:colornames.Black},
 		StdWidth: 1.9,
 		Opacity:  1,
 	},
 	"mechanical pencil": {
-		Colour:   colornames.Black,
+		Colour:   map[int]color.RGBA{0:colornames.Black},
 		StdWidth: 1.2,
 		Opacity:  0.7,
 	},
 	"paint": {
-		Colour:   color.RGBA{55, 55, 55, 220}, // dark grey
+		Colour:   map[int]color.RGBA{ 0:color.RGBA{55, 55, 55, 220}, 1:color.RGBA{88, 88, 88, 220}, 2:color.RGBA{220, 220, 220, 220} },
 		StdWidth: 4.8,
 		Opacity:  0.8,
 	},
 	"eraser": {
-		Colour:   colornames.White,
+		Colour:   map[int]color.RGBA{0:colornames.White},
 		StdWidth: 9.0,
 		Opacity:  0,
 	},
 	"erase area": {
-		Colour:   colornames.White,
+		Colour:   map[int]color.RGBA{0:colornames.White},
 		StdWidth: 9.0,
 		Opacity:  0,
 	},
@@ -133,15 +133,19 @@ func (s *StrokeSetting) Width(penwidth float32) float64 {
 // Given a colour, determine if the stroke is overrideable (using the
 // ColourOverride attribute); if so return the RGB of the
 // given colour, else return the RGB of the native colour
-func (s *StrokeSetting) selectColour(lc *LocalColour) (int, int, int) {
+func (s *StrokeSetting) selectColour(lc *LocalColour, rmColour uint32) (int, int, int) {
 	c := color.RGBA{}
-	if lc.Name == "" || lc.Name == "empty" {
-		c = s.Colour
-	} else if !s.ColourOverride {
-		c = s.Colour
+
+	if lc.Name == "" || lc.Name == "empty"  || !s.ColourOverride {
+		foundColour, exists := s.Colour[int(rmColour)]
+		if(!exists) {
+			foundColour = s.Colour[0]
+		}
+		c = foundColour
 	} else {
 		c = lc.Colour
 	}
+
 	r := int(c.R)
 	g := int(c.G)
 	b := int(c.B)

--- a/rmpdf/stroke.go
+++ b/rmpdf/stroke.go
@@ -130,14 +130,6 @@ func (s *StrokeSetting) Width(penwidth float32) float64 {
 	return float64(r)
 }
 
-// Return the rbg components of the stroke's colour
-func (s *StrokeSetting) toRGB() (int, int, int) {
-	r := int(s.Colour.R)
-	g := int(s.Colour.G)
-	b := int(s.Colour.B)
-	return int(r), int(g), int(b)
-}
-
 // Given a colour, determine if the stroke is overrideable (using the
 // ColourOverride attribute); if so return the RGB of the
 // given colour, else return the RGB of the native colour
@@ -155,8 +147,3 @@ func (s *StrokeSetting) selectColour(lc *LocalColour) (int, int, int) {
 	b := int(c.B)
 	return int(r), int(g), int(b)
 }
-
-// Return the cmyk components of the stroke's colour
-// func (s *StrokeSetting) toCMYK() color.CMYK {
-// 	return color.CMYKModel.Convert(s.Colour)
-// }


### PR DESCRIPTION
Use detected pen colours:


![image](https://user-images.githubusercontent.com/662538/104287105-44cd0500-54b6-11eb-97cb-44a29c0aebe9.png)

[rmData.zip](https://github.com/rorycl/rm2pdf/files/5800686/rmData.zip)



The colours still need some fine-tuning (but I'm not a colour person). I made some pens green because that comes in handy for me when grading.